### PR TITLE
Make function generics less restrictive

### DIFF
--- a/src/de_funcs.rs
+++ b/src/de_funcs.rs
@@ -20,7 +20,7 @@ pub fn decompress_file(src_path: impl AsRef<Path>, dest: impl AsRef<Path>) -> Re
 pub fn decompress_file_with_extract_fn(
     src_path: impl AsRef<Path>,
     dest: impl AsRef<Path>,
-    extract_fn: impl Fn(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+    extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
 ) -> Result<(), Error> {
     let file = std::fs::File::open(src_path.as_ref())
         .map_err(|e| Error::file_open(e, src_path.as_ref().to_string_lossy().to_string()))?;
@@ -38,7 +38,7 @@ pub fn decompress<R: Read + Seek>(src_reader: R, dest: impl AsRef<Path>) -> Resu
 pub fn decompress_with_extract_fn<R: Read + Seek>(
     src_reader: R,
     dest: impl AsRef<Path>,
-    extract_fn: impl Fn(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+    extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
 ) -> Result<(), Error> {
     decompress_impl(src_reader, dest, Password::empty(), extract_fn)
 }
@@ -76,7 +76,7 @@ pub fn decompress_with_extract_fn_and_password<R: Read + Seek>(
     mut src_reader: R,
     dest: impl AsRef<Path>,
     password: Password,
-    extract_fn: impl Fn(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+    extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
 ) -> Result<(), Error> {
     decompress_impl(src_reader, dest, password, extract_fn)
 }
@@ -86,7 +86,7 @@ fn decompress_impl<R: Read + Seek>(
     mut src_reader: R,
     dest: impl AsRef<Path>,
     password: Password,
-    extract_fn: impl Fn(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+    mut extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
 ) -> Result<(), Error> {
     use std::io::SeekFrom;
 


### PR DESCRIPTION
From the documentation of [`FnMut`](https://doc.rust-lang.org/nightly/std/ops/trait.FnMut.html):

> Since [`FnOnce`](https://github.com/dyz1990/sevenz-rust/issues/trait.FnOnce.html) is a supertrait of `FnMut`, any instance of `FnMut` can be used where a [`FnOnce`](https://github.com/dyz1990/sevenz-rust/issues/trait.FnOnce.html) is expected, and since [`Fn`](https://github.com/dyz1990/sevenz-rust/issues/trait.Fn.html) is a subtrait of `FnMut`, any instance of [`Fn`](https://github.com/dyz1990/sevenz-rust/issues/trait.Fn.html) can be used where `FnMut` is expected.

And from the docs of [`Fn`](https://doc.rust-lang.org/nightly/std/ops/trait.Fn.html):

> Use `Fn` as a bound when you want to accept a parameter of function-like type and need to call it repeatedly and without mutating state (e.g., when calling it concurrently). If you do not need such strict requirements, use [`FnMut`](https://github.com/dyz1990/sevenz-rust/issues/trait.FnMut.html) or [`FnOnce`](https://github.com/dyz1990/sevenz-rust/issues/trait.FnOnce.html) as bounds.

Basically `Fn` is more restrictive, and if you don't need the restrictions, you should go with `FnMut` or `FnOnce`.

Here's a [real example](https://github.com/ouch-org/ouch/pull/393/files) where `Fn` instead of `FnMut` generated an slightly more complicated code:

```rust
use std::cell::RefCell;

let a = RefCell::new(Vec::new());

sevenz_rust::decompress_file_with_extract_fn(archive_path, ".", |entry, _, _| {
    let name = entry.name().to_string();
    a.borrow_mut().push(name);
    Ok(true)
})
```

By replacing `Fn` by `FnMut`:

```rust
let a = Vec::new(); // simplified here

sevenz_rust::decompress_file_with_extract_fn(archive_path, ".", |entry, _, _| {
    let name = entry.name().to_string();
    a.push(name); // simplified here
    Ok(true)
})
```
