### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["compress"]
 aes = {version = "0.8", optional = true}
 bit-set = "0.5.3"
 byteorder = "1.4"
-bzip2 = {version = "0.4", optional = true}
+bzip2 = {version = "0.4.4", optional = true}
 cbc = {version = "0.1", optional = true}
 crc = "3.0.0"
 filetime_creation = "0.1"


### PR DESCRIPTION
Updates bzip dependency to the patch version of 0.4.4

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0004.html)
[fix](https://github.com/alexcrichton/bzip2-rs/pull/86)