### PR TITLE
allow default SevenZArchiveEntry creation

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -78,6 +78,10 @@ pub struct SevenZArchiveEntry {
 }
 
 impl SevenZArchiveEntry {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }


### PR DESCRIPTION
The use case that I'd like to enable is to be able to create archive entries from Vec<u8>'s. Similarly to how they are created in the wasm code. This change would allow the creation of archive entries without the need to provide a path.