### PR TITLE
Set MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,28 +12,32 @@ env:
 jobs:
   build:
     runs-on: ${{matrix.os}}
-    strategy: 
+    strategy:
       matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        toolchain:
+          - stable
+          - 1.67.0 # MSRV
         include:
           - os: macos-latest
-            name: macos_x86_64
             target: x86_64-apple-darwin
           - os: ubuntu-latest
-            name: linux_x86_64
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
-            name: windows_x86_64
             target: x86_64-pc-windows-msvc
     steps:
-    - uses: actions/checkout@v4
-    - name: Install rust version
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        target: ${{matrix.target}}
-    - uses: actions/checkout@v4
-    - name: Run tests
-      run: cargo test --verbose --release --all-features
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{matrix.toolchain}}
+          target: ${{matrix.target}}
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: cargo test --verbose --release --all-features
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 name = "sevenz-rust"
 readme = "README.md"
 repository = "https://github.com/dyz1990/sevenz-rust"
+rust-version = "1.67.0"
 version = "0.5.3"
 
 [lib]

--- a/lzma-rust/Cargo.toml
+++ b/lzma-rust/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 homepage = "https://github.com/dyz1990/sevenz-rust/tree/main/lzma-rust"
 name = "lzma-rust"
 repository = "https://github.com/dyz1990/sevenz-rust/tree/main/lzma-rust"
+rust-version = "1.60.0"
 version = "0.1.5"
 keywords = ["lzma"]
 license = "Apache-2.0"


### PR DESCRIPTION
Add the `rust-version` field to `Cargo.toml`. The minimal supported Rust version (MSRV) was determined based on [cargo-msrv](https://github.com/foresterre/cargo-msrv).